### PR TITLE
Fixed NullReferenceExceptions for properties where the value is actually 'null'

### DIFF
--- a/ComparisonApp/Compare.cs
+++ b/ComparisonApp/Compare.cs
@@ -12,7 +12,7 @@ public class Compare
         {
             object value1 = property.GetValue(test1, null);
             object value2 = property.GetValue(test2, null);
-            if (!value1.Equals(value2))
+            if (!Object.Equals(value1, value2))
             {
                 differences.Add(property);
             }
@@ -30,7 +30,7 @@ public class Compare
             object value1 = property.GetValue(first, null);
             object value2 = property.GetValue(second, null);
 
-            if (!value1.Equals(value2))
+            if (!Object.Equals(value1, value2))
             {
                 differences.Add(property);
             }


### PR DESCRIPTION
For some properties the value null is actually valid, eg. `Employee.MiddleName`.
In those cases, `value1` would be `null` and thus cause the NRE you were experiencing.
My quick fix suggestion would be to use the static `Object.Equals()` method, but you could also write a custom comparison method yourself.